### PR TITLE
fix: type importing

### DIFF
--- a/prisma/mongodb.prisma
+++ b/prisma/mongodb.prisma
@@ -27,6 +27,14 @@ type DealerProfile {
   bio      String
 }
 
+model Deals {
+  id        String   @id @default(auto()) @map("_id") @db.ObjectId
+  amount    Int
+  dealer    Dealer   @relation(fields: [dealerId], references: [id])
+  dealerId  String   @db.ObjectId
+  createdAt DateTime @default(now())
+}
+
 model Dealer {
   id         String          @id @default(auto()) @map("_id") @db.ObjectId
   createdAt  DateTime?       @default(now())
@@ -36,6 +44,7 @@ model Dealer {
   address    Address
   dealerType DealerType      @default(Basic)
   profiles   DealerProfile[]
+  deals      Deals[]
 
   @@map("dealers")
 }

--- a/src/components/class.component.ts
+++ b/src/components/class.component.ts
@@ -11,7 +11,7 @@ export class ClassComponent extends BaseComponent implements Echoable {
 	fields?: FieldComponent[]
 	relationTypes?: string[]
 	enumTypes?: string[] = []
-	objectTypes?: string[] = []
+	typeTypes?: string[] = []
 	extra?: string = ''
 
 	echo = () => {

--- a/src/components/file.component.ts
+++ b/src/components/file.component.ts
@@ -95,9 +95,9 @@ export class FileComponent implements Echoable {
 			)
 		})
 
-		this.prismaClass.objectTypes.forEach((objectName) => {
+		this.prismaClass.typeTypes.forEach((typeName) => {
 			this.registerImport(
-				objectName,
+				typeName,
 				customClientImportPath ?? generator.getClientImportPath(),
 			)
 		})

--- a/src/convertor.ts
+++ b/src/convertor.ts
@@ -217,7 +217,10 @@ export class PrismaConvertor {
 				.map((v) => v.type),
 		)
 		const enums = model.fields.filter((field) => field.kind === 'enum')
-		const objects = model.fields.filter((field) => field.kind === 'object')
+		const types = model.fields.filter(
+			(field) =>
+				field.kind === 'object' && field.relationName === undefined,
+		)
 
 		classComponent.fields = model.fields
 			.filter((field) => {
@@ -238,10 +241,10 @@ export class PrismaConvertor {
 				? []
 				: enums.map((field) => field.type.toString())
 
-		classComponent.objectTypes =
+		classComponent.typeTypes =
 			extractRelationFields === true
 				? []
-				: objects.map((field) => field.type.toString())
+				: types.map((field) => field.type.toString())
 
 		if (useGraphQL) {
 			const deco = new DecoratorComponent({


### PR DESCRIPTION
## Proposed Changes

- Include `Type Field` type in prisma importing

## Before

```prisma
type DealerProfile {
  nickname String
  bio      String
}

model Dealer {
  id         String          @id @default(auto()) @map("_id") @db.ObjectId
  profiles   DealerProfile[]
}
```

```ts
import { ApiProperty } from '@nestjs/swagger'

export class Dealer {
	@ApiProperty({ type: String })
	id: string

	@ApiProperty({ isArray: true })
	// Cannot find name 'DealerProfile'.ts(2304)
	profiles: DealerProfile[]
}
```
## Now

```ts
import { DealerProfile } from '@prisma/client'
import { ApiProperty } from '@nestjs/swagger'

export class Dealer {
	@ApiProperty({ type: String })
	id: string

	@ApiProperty({ isArray: true })
	profiles: DealerProfile[]
}
```